### PR TITLE
Refactor CSS: Separate page

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -1,0 +1,105 @@
+/* Dashboard Page Specific Styles */
+
+body.dashboard-page {
+    background-color: #f5f5f5;
+}
+
+.dashboard-content-wrapper {
+    padding: 20px 0;
+    min-height: calc(100vh - 70px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+body.dashboard-page h1 {
+    text-align: center;
+    margin-bottom: 20px;
+    font-size: 28px;
+    margin-top: 0;
+}
+
+/* File Input Styling */
+body.dashboard-page input[type="file"] {
+    display: block;
+    max-width: 300px;
+    margin: 0 auto 30px auto;
+    padding: 10px 15px;
+    background-color: #eee;
+    color: #333;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 16px;
+}
+
+body.dashboard-page input[type="file"]:focus {
+    outline: none;
+    border-color: #3498db;
+    box-shadow: 0 0 5px rgba(52, 152, 219, 0.5);
+}
+
+/* Dashboard Grid Layout */
+.dashboard {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(2, auto);
+    gap: 20px;
+    width: 100%;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.dashboard .card {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+}
+
+.dashboard .card canvas {
+    width: 100% !important;
+    height: auto !important;
+    max-height: 250px;
+}
+
+.dashboard .card h2 {
+    color: #2c3e50;
+    font-size: 20px;
+    margin-bottom: 10px;
+}
+
+/* Top Expenses List */
+#topExpenses {
+    list-style: none;
+    margin: 0;
+    padding: 0 10px;
+    color: #333;
+    font-size: 15px;
+    overflow-y: auto;
+    width: 100%;
+}
+
+#topExpenses li {
+    padding: 8px 0;
+    border-bottom: 1px solid #eee;
+}
+
+#topExpenses li:last-child {
+    border-bottom: none;
+}
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+    .dashboard {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto;
+    }
+}
+
+@media (max-width: 480px) {
+    body.dashboard-page h1 {
+        font-size: 24px;
+    }
+}

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1,0 +1,121 @@
+/* Home Page Specific Styles */
+
+/* Hero Section */
+.hero {
+    padding: 80px 0;
+    text-align: center;
+}
+
+.hero h1 {
+    font-size: 48px;
+    margin-bottom: 20px;
+    color: #2c3e50;
+}
+
+.hero p {
+    font-size: 20px;
+    color: #7f8c8d;
+    max-width: 800px;
+    margin: 0 auto 40px;
+}
+
+/* Features Section */
+.features {
+    padding: 60px 0;
+    background-color: white;
+}
+
+.section-title {
+    text-align: center;
+    margin-bottom: 50px;
+}
+
+.section-title h2 {
+    font-size: 36px;
+    color: #2c3e50;
+    margin-bottom: 15px;
+}
+
+.section-title p {
+    color: #7f8c8d;
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 30px;
+}
+
+.feature-card {
+    padding: 30px;
+    border-radius: 8px;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.05);
+    transition: all 0.3s ease;
+}
+
+.feature-card:hover {
+    transform: translateY(-10px);
+    box-shadow: 0 15px 30px rgba(0, 0, 0, 0.1);
+}
+
+.feature-icon {
+    font-size: 40px;
+    margin-bottom: 20px;
+    color: #3498db;
+}
+
+.feature-card h3 {
+    font-size: 22px;
+    margin-bottom: 15px;
+    color: #2c3e50;
+}
+
+/* Dashboard Preview */
+.dashboard-preview {
+    margin-top: 40px;
+    text-align: center;
+    background-color: white;
+    border-radius: 10px;
+    padding: 20px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+.charts-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+    margin-top: 20px;
+}
+
+.chart-box {
+    width: 48%;
+    margin-bottom: 20px;
+    padding: 15px;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+}
+
+.chart-title {
+    font-size: 18px;
+    color: #2c3e50;
+    margin-bottom: 10px;
+    text-align: center;
+}
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+    .hero h1 {
+        font-size: 36px;
+    }
+
+    .hero p {
+        font-size: 18px;
+    }
+
+    .chart-box {
+        width: 100%;
+    }
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,9 +1,9 @@
-/* styles for index.html */
+/* Reset and Base Styles */
 * {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
 body {
@@ -20,6 +20,35 @@ body {
     padding: 0 20px;
 }
 
+/* Typography */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    color: #2c3e50;
+    margin-bottom: 0.5em;
+    font-weight: 600;
+}
+
+p {
+    margin-bottom: 1em;
+}
+
+a {
+    color: #3498db;
+    text-decoration: none;
+    transition: all 0.3s ease;
+}
+
+a:hover {
+    color: #2980b9;
+}
+
+/* Layout Components */
+
+/* Header */
 header {
     background-color: #1a1a2e;
     color: white;
@@ -60,8 +89,7 @@ nav {
     flex-shrink: 0;
 }
 
-
-/* Styling for the main navigation links (Home, Upload, Dashboard, Share) */
+/* Navigation Links */
 .primary-nav .nav-link {
     text-decoration: none;
     color: #bdc3c7;
@@ -80,23 +108,15 @@ nav {
 .primary-nav .nav-link:hover {
     background-color: rgba(255, 255, 255, 0.1);
     color: white;
-    transform: none;
-    box-shadow: none;
-    opacity: 1;
 }
 
-/* Styling for the active navigation link (like 'Home' in the image) */
 .primary-nav .nav-link.active {
     background-color: #34495e;
-    /* Darker background for active state */
     color: white;
-    /* White text for active state */
     font-weight: bold;
-    /* Make active link text bold */
 }
 
-
-/* Styling for Login/Sign Up buttons */
+/* Auth Buttons */
 .auth-buttons a {
     text-decoration: none;
     padding: 8px 16px;
@@ -123,25 +143,7 @@ nav {
     transform: translateY(-2px);
 }
 
-
-.hero {
-    padding: 80px 0;
-    text-align: center;
-}
-
-.hero h1 {
-    font-size: 48px;
-    margin-bottom: 20px;
-    color: #2c3e50;
-}
-
-.hero p {
-    font-size: 20px;
-    color: #7f8c8d;
-    max-width: 800px;
-    margin: 0 auto 40px;
-}
-
+/* Common Button Styles */
 .cta-btn {
     display: inline-block;
     background-color: #3498db;
@@ -154,6 +156,7 @@ nav {
     font-weight: bold;
     transition: all 0.3s ease;
     margin: 0 10px;
+    cursor: pointer;
 }
 
 .cta-btn:hover {
@@ -168,377 +171,16 @@ nav {
     border: 1px solid #3498db;
 }
 
-.features {
-    padding: 60px 0;
-    background-color: white;
-}
-
-.section-title {
-    text-align: center;
-    margin-bottom: 50px;
-}
-
-.section-title h2 {
-    font-size: 36px;
-    color: #2c3e50;
-    margin-bottom: 15px;
-}
-
-.section-title p {
-    color: #7f8c8d;
-    max-width: 700px;
-    margin: 0 auto;
-}
-
-.feature-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 30px;
-}
-
-.feature-card {
-    padding: 30px;
-    border-radius: 8px;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.05);
-    transition: all 0.3s ease;
-}
-
-.feature-card:hover {
-    transform: translateY(-10px);
-    box-shadow: 0 15px 30px rgba(0, 0, 0, 0.1);
-}
-
-.feature-icon {
-    font-size: 40px;
-    margin-bottom: 20px;
-    color: #3498db;
-}
-
-.feature-card h3 {
-    font-size: 22px;
-    margin-bottom: 15px;
-    color: #2c3e50;
-}
-
-footer {
-    background-color: #2c3e50;
-    color: white;
-    padding: 30px 0;
-    text-align: center;
-}
-
-.dashboard-preview {
-    margin-top: 40px;
-    text-align: center;
-    background-color: white;
-    border-radius: 10px;
-    padding: 20px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-}
-
-.charts-container {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-around;
-    margin-top: 20px;
-}
-
-.chart-box {
-    width: 48%;
-    margin-bottom: 20px;
-    padding: 15px;
-    background-color: #fff;
-    border-radius: 8px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
-}
-
-.chart-title {
-    font-size: 18px;
-    color: #2c3e50;
-    margin-bottom: 10px;
-    text-align: center;
-}
-
-
-/* --- Dashboard Specific Styles --- */
-
-body.dashboard-page {
-    background-color: #f5f5f5;
-    color: #333;
-    padding: 0;
-}
-
-/* Style for the main content wrapper on the dashboard page */
-.dashboard-content-wrapper,
-.upload-content-wrapper {
-    padding: 20px 0;
-    min-height: calc(100vh - 70px);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-}
-
-body.dashboard-page h1 {
-    text-align: center;
-    color: #2c3e50;
-    margin-bottom: 20px;
-    font-size: 28px;
-    margin-top: 0;
-}
-
-/* Style for the file input (adjusted for light background) */
-body.dashboard-page input[type="file"] {
-    display: block;
-    max-width: 300px;
-    margin: 0 auto 30px auto;
-    padding: 10px 15px;
-    background-color: #eee;
-    color: #333;
-    border: 1px solid #ccc;
-    border-radius: 8px;
-    cursor: pointer;
-    font-size: 16px;
-}
-
-/* Dashboard grid layout for 2x2 on larger screens */
-.dashboard {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(2, auto);
-    gap: 20px;
-    width: 100%;
-    max-width: 1000px;
-    margin: 0 auto;
-}
-
+/* Card Component */
 .card {
     background: white;
     padding: 16px;
     border-radius: 16px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     overflow: hidden;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
 }
 
-.card canvas {
-    width: 100% !important;
-    height: auto !important;
-    max-height: 250px;
-}
-
-.card h2 {
-    color: #2c3e50;
-    font-size: 20px;
-    margin-bottom: 10px;
-}
-
-#topExpenses {
-    list-style: none;
-    margin: 0;
-    padding: 0 10px;
-    color: #333;
-    font-size: 15px;
-    overflow-y: auto;
-    width: 100%;
-}
-
-#topExpenses li {
-    padding: 8px 0;
-    border-bottom: 1px solid #eee;
-}
-
-#topExpenses li:last-child {
-    border-bottom: none;
-}
-
-/* --- Share view Specific Styles --- */
-
-/* Style for select and text input fields within the form */
-.share-page .data-selection-form select,
-.share-page .data-selection-form input[type="text"] {
-    width: 100%;
-    padding: 10px 12px;
-    margin-bottom: 15px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    font-size: 16px;
-    color: #555;
-    background-color: #fff;
-    box-sizing: border-box;
-
-    .data-selection-form select:focus,
-    .data-selection-form input[type="text"]:focus,
-    body.dashboard-page input[type="file"]:focus {
-        outline: none;
-        border-color: #3498db;
-        box-shadow: 0 0 5px rgba(52, 152, 219, 0.5);
-    }
-
-    /Style for multi-select */ .data-selection-form select[multiple] {
-        min-height: 100px;
-    }
-
-    .form-group {
-        margin-bottom: 20px;
-    }
-
-    .form-group label {
-        display: block;
-        margin-bottom: 8px;
-        font-weight: bold;
-        color: #555;
-    }
-
-}
-
-.share-page .dashboard-content-wrapper h1 {
-    text-align: center;
-    margin-bottom: 20px;
-}
-
-/* Media Queries */
-@media (max-width: 768px) {
-
-    nav {
-        flex-direction: column;
-        gap: 10px;
-    }
-
-    .logo {
-        margin-right: 0;
-        margin-bottom: 10px;
-    }
-
-    .primary-nav,
-    .auth-buttons {
-        width: 100%;
-        justify-content: center;
-        gap: 10px;
-    }
-
-    /* Dashboard grid responsiveness */
-    .dashboard {
-        grid-template-columns: 1fr;
-        grid-template-rows: auto;
-    }
-
-}
-
-@media (max-width: 480px) {
-
-    /* Further adjustments for very small screens */
-    .primary-nav .nav-link {
-        padding: 6px 10px;
-        font-size: 14px;
-    }
-
-    .auth-buttons a {
-        padding: 6px 10px;
-        font-size: 14px;
-    }
-
-    body.dashboard-page h1 {
-        font-size: 24px;
-    }
-}
-
-body.upload-page h1 {
-    text-align: center;
-    color: #2c3e50;
-    margin-bottom: 20px;
-    font-size: 28px;
-    margin-top: 0;
-}
-
-.subtitle {
-    text-align: center;
-    color: #7f8c8d;
-    margin-bottom: 40px;
-    font-size: 16px;
-}
-
-.upload-options {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-    gap: 30px;
-    max-width: 900px;
-    margin: 0 auto;
-}
-
-.upload-card {
-    background: white;
-    padding: 30px;
-    border-radius: 16px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    text-align: center;
-}
-
-.upload-icon {
-    width: 60px;
-    height: 60px;
-    margin: 0 auto 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: #f0f8ff;
-    border-radius: 50%;
-    color: #3498db;
-}
-
-.upload-card h2 {
-    color: #2c3e50;
-    font-size: 22px;
-    margin-bottom: 10px;
-}
-
-.upload-card p {
-    color: #7f8c8d;
-    margin-bottom: 20px;
-    font-size: 15px;
-}
-
-.file-input {
-    display: block;
-    width: 100%;
-    margin: 20px 0;
-    padding: 10px;
-    border: 1px dashed #ccc;
-    border-radius: 8px;
-    background-color: #f9f9f9;
-    cursor: pointer;
-}
-
-.upload-btn,
-.submit-btn {
-    margin-top: 10px;
-    display: inline-block;
-    background-color: #3498db;
-    color: white;
-    padding: 12px 25px;
-    border: none;
-    border-radius: 30px;
-    text-decoration: none;
-    font-size: 16px;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    cursor: pointer;
-    width: 100%;
-}
-
-.upload-btn:hover,
-.submit-btn:hover {
-    background-color: #2980b9;
-    transform: translateY(-2px);
-}
-
-.entry-form {
-    margin-top: 20px;
-    text-align: left;
-}
-
+/* Form Elements */
 .form-group {
     margin-bottom: 15px;
 }
@@ -569,13 +211,53 @@ body.upload-page h1 {
     box-shadow: 0 0 5px rgba(52, 152, 219, 0.3);
 }
 
-/* Responsive adjustments */
+/* Footer */
+footer {
+    background-color: #2c3e50;
+    color: white;
+    padding: 30px 0;
+    text-align: center;
+}
+
+/* Content Wrapper */
+.content-wrapper {
+    padding: 20px 0;
+    min-height: calc(100vh - 140px);
+    /* Adjust based on header/footer height */
+}
+
+/* Media Queries */
 @media (max-width: 768px) {
-    .upload-options {
-        grid-template-columns: 1fr;
+    nav {
+        flex-direction: column;
+        gap: 10px;
     }
 
-    .upload-card {
-        padding: 20px;
+    .logo {
+        margin-right: 0;
+        margin-bottom: 10px;
+    }
+
+    .primary-nav,
+    .auth-buttons {
+        width: 100%;
+        justify-content: center;
+        gap: 10px;
+    }
+}
+
+@media (max-width: 480px) {
+    .primary-nav .nav-link {
+        padding: 6px 10px;
+        font-size: 14px;
+    }
+
+    .auth-buttons a {
+        padding: 6px 10px;
+        font-size: 14px;
+    }
+
+    h1 {
+        font-size: 24px;
     }
 }

--- a/static/css/share.css
+++ b/static/css/share.css
@@ -1,0 +1,114 @@
+/* Share Page Specific Styles */
+
+.share-page .dashboard-content-wrapper h1 {
+    text-align: center;
+    margin-bottom: 20px;
+    color: #2c3e50;
+    font-size: 28px;
+}
+
+.share-page .subtitle {
+    text-align: center;
+    color: #7f8c8d;
+    margin-bottom: 30px;
+    font-size: 16px;
+}
+
+.share-options-card {
+    background: white;
+    padding: 30px;
+    border-radius: 16px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.share-options-card h2 {
+    color: #2c3e50;
+    font-size: 22px;
+    margin-bottom: 10px;
+}
+
+/* Form Field Styling */
+.share-page .data-selection-form select,
+.share-page .data-selection-form input[type="text"] {
+    width: 100%;
+    padding: 10px 12px;
+    margin-bottom: 15px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 16px;
+    color: #555;
+    background-color: #fff;
+    box-sizing: border-box;
+}
+
+.share-page .data-selection-form select:focus,
+.share-page .data-selection-form input[type="text"]:focus {
+    outline: none;
+    border-color: #3498db;
+    box-shadow: 0 0 5px rgba(52, 152, 219, 0.5);
+}
+
+/* Multi-select Styling */
+.share-page .data-selection-form select[multiple] {
+    min-height: 100px;
+}
+
+.share-page .form-group {
+    margin-bottom: 20px;
+}
+
+.share-page .form-group label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: bold;
+    color: #555;
+}
+
+/* Button Styling */
+.share-page .share-btn {
+    margin-top: 20px;
+    display: inline-block;
+    background-color: #3498db;
+    color: white;
+    padding: 12px 25px;
+    border: none;
+    border-radius: 30px;
+    text-decoration: none;
+    font-size: 16px;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    cursor: pointer;
+    width: 100%;
+}
+
+.share-page .share-btn:hover {
+    background-color: #2980b9;
+    transform: translateY(-2px);
+}
+
+/* Shared Links Card */
+.shared-links-card {
+    margin-top: 20px;
+    max-width: 800px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.shared-links-card ul {
+    list-style: none;
+    padding: 0;
+}
+
+.shared-links-card li {
+    padding: 10px 0;
+    border-bottom: 1px solid #eee;
+}
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+    .share-options-card {
+        padding: 20px;
+    }
+}

--- a/static/css/upload.css
+++ b/static/css/upload.css
@@ -1,0 +1,117 @@
+/* Upload Page Specific Styles */
+
+body.upload-page h1 {
+    text-align: center;
+    margin-bottom: 20px;
+    font-size: 28px;
+    margin-top: 0;
+}
+
+.upload-content-wrapper {
+    padding: 20px 0;
+    min-height: calc(100vh - 70px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.subtitle {
+    text-align: center;
+    color: #7f8c8d;
+    margin-bottom: 40px;
+    font-size: 16px;
+}
+
+/* Upload Options Grid */
+.upload-options {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    gap: 30px;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.upload-card {
+    background: white;
+    padding: 30px;
+    border-radius: 16px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    text-align: center;
+}
+
+.upload-icon {
+    width: 60px;
+    height: 60px;
+    margin: 0 auto 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #f0f8ff;
+    border-radius: 50%;
+    color: #3498db;
+}
+
+.upload-card h2 {
+    color: #2c3e50;
+    font-size: 22px;
+    margin-bottom: 10px;
+}
+
+.upload-card p {
+    color: #7f8c8d;
+    margin-bottom: 20px;
+    font-size: 15px;
+}
+
+/* File Input Styling */
+.file-input {
+    display: block;
+    width: 100%;
+    margin: 20px 0;
+    padding: 10px;
+    border: 1px dashed #ccc;
+    border-radius: 8px;
+    background-color: #f9f9f9;
+    cursor: pointer;
+}
+
+/* Button Styling */
+.upload-btn,
+.submit-btn {
+    margin-top: 10px;
+    display: inline-block;
+    background-color: #3498db;
+    color: white;
+    padding: 12px 25px;
+    border: none;
+    border-radius: 30px;
+    text-decoration: none;
+    font-size: 16px;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    cursor: pointer;
+    width: 100%;
+}
+
+.upload-btn:hover,
+.submit-btn:hover {
+    background-color: #2980b9;
+    transform: translateY(-2px);
+}
+
+/* Form Styling */
+.entry-form {
+    margin-top: 20px;
+    text-align: left;
+}
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+    .upload-options {
+        grid-template-columns: 1fr;
+    }
+
+    .upload-card {
+        padding: 20px;
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <!-- Common CSS -->
         <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+        <!-- Page-specific CSS -->
+        {% block page_css %}{% endblock %}
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
         <!-- Page-specific title -->
         <title>{% block title %}BudgetTrack{% endblock %}</title>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,5 +1,9 @@
 {% extends 'base.html' %}
 
+{% block page_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
+{% endblock %}
+
 {% block title %}BudgetTrack - Dashboard{% endblock %}
 
 {% block head %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,9 @@
 {% extends 'base.html' %}
 
+{% block page_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/index.css') }}">
+{% endblock %}
+
 {% block title %}BudgetTrack - Smart Expense Tracking{% endblock %}
 
 {% block head %}

--- a/templates/share.html
+++ b/templates/share.html
@@ -1,5 +1,9 @@
 {% extends 'base.html' %}
 
+{% block page_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/share.css') }}">
+{% endblock %}
+
 {% block title %}BudgetTrack - Share Data{% endblock %}
 
 {% block body_class %}share-page{% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,5 +1,9 @@
 {% extends 'base.html' %}
 
+{% block page_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/upload.css') }}">
+{% endblock %}
+
 {% block title %}BudgetTrack - Upload Expenses{% endblock %}
 
 {% block body_class %}upload-page{% endblock %}


### PR DESCRIPTION
This PR refactors the existing CSS structure to improve modularity and maintainability. Previously, all styles were included in a single main.css file for all pages. The changes in this PR include:

- Extracted common styles into main.css
- Created four page-specific CSS files
- Updated base.html to include page specific CSS block
- Modified individual HTML templates (index.html, upload.html, dashboard.html, share.html) to load their corresponding CSS files

Reasons for this Change:
- Keep shared and page-specific styles isolated
- Make future styling changes easier to manage 
- Reduce unnecessary CSS loading on pages where styles are not used


